### PR TITLE
FIX: reverse editors when no author is present (#43)

### DIFF
--- a/dist/reference.hbs
+++ b/dist/reference.hbs
@@ -16,18 +16,32 @@
 {{!-- editor list --}}
 {{#*inline "editors"}}
   {{#each editors}}
+
     {{!-- add an ampersand before the last name --}}
     {{#if @last}}
       {{#unless @first}}&amp;{{/unless}}
     {{/if}}
+
     {{!-- name --}}
-    {{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+    {{!-- use reversed names for first editor if no authors are present --}}
+    {{#if ../authors}}{{!--
+      --}}{{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+    --}}{{else}}{{!--
+      --}}{{#if @first}}{{!--
+        --}}{{last_name}}{{#if first_name}}, {{first_name}}{{/if}}{{!--
+      --}}{{else}}{{!--
+        --}}{{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+      --}}{{/if}}{{!--
+    --}}{{/if}}{{!--
+
     add a comma after each name
-    --}}{{#unless @last}},{{/unless}}{{!--
-    add the (ed(s).) after the list of names
-    --}}{{#if @last}}
+    --}}{{#unless @last}},{{/unless}}
+
+    {{!-- add the (ed(s).) after the list of names --}}
+    {{#if @last}}
       {{#if @first}}(ed.){{else}}(eds.){{/if}}{{!--
     --}}{{/if}}{{!--
+
   --}}{{/each}}{{!--
 --}}{{/inline}}
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,6 @@
 {
   "exec": "npm test",
-  "ext": "hbs,js",
+  "ext": "hbs,js,json",
   "ignore": [
     "dist/*",
     "test/*"

--- a/src/reference.hbs
+++ b/src/reference.hbs
@@ -16,18 +16,32 @@
 {{!-- editor list --}}
 {{#*inline "editors"}}
   {{#each editors}}
+
     {{!-- add an ampersand before the last name --}}
     {{#if @last}}
       {{#unless @first}}&amp;{{/unless}}
     {{/if}}
+
     {{!-- name --}}
-    {{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+    {{!-- use reversed names for first editor if no authors are present --}}
+    {{#if ../authors}}{{!--
+      --}}{{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+    --}}{{else}}{{!--
+      --}}{{#if @first}}{{!--
+        --}}{{last_name}}{{#if first_name}}, {{first_name}}{{/if}}{{!--
+      --}}{{else}}{{!--
+        --}}{{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+      --}}{{/if}}{{!--
+    --}}{{/if}}{{!--
+
     add a comma after each name
-    --}}{{#unless @last}},{{/unless}}{{!--
-    add the (ed(s).) after the list of names
-    --}}{{#if @last}}
+    --}}{{#unless @last}},{{/unless}}
+
+    {{!-- add the (ed(s).) after the list of names --}}
+    {{#if @last}}
       {{#if @first}}(ed.){{else}}(eds.){{/if}}{{!--
     --}}{{/if}}{{!--
+
   --}}{{/each}}{{!--
 --}}{{/inline}}
 

--- a/test/reference.hbs
+++ b/test/reference.hbs
@@ -16,18 +16,32 @@
 {{!-- editor list --}}
 {{#*inline "editors"}}
   {{#each editors}}
+
     {{!-- add an ampersand before the last name --}}
     {{#if @last}}
       {{#unless @first}}&amp;{{/unless}}
     {{/if}}
+
     {{!-- name --}}
-    {{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+    {{!-- use reversed names for first editor if no authors are present --}}
+    {{#if ../authors}}{{!--
+      --}}{{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+    --}}{{else}}{{!--
+      --}}{{#if @first}}{{!--
+        --}}{{last_name}}{{#if first_name}}, {{first_name}}{{/if}}{{!--
+      --}}{{else}}{{!--
+        --}}{{#if first_name}}{{first_name}} {{/if}}{{last_name}}{{!--
+      --}}{{/if}}{{!--
+    --}}{{/if}}{{!--
+
     add a comma after each name
-    --}}{{#unless @last}},{{/unless}}{{!--
-    add the (ed(s).) after the list of names
-    --}}{{#if @last}}
+    --}}{{#unless @last}},{{/unless}}
+
+    {{!-- add the (ed(s).) after the list of names --}}
+    {{#if @last}}
       {{#if @first}}(ed.){{else}}(eds.){{/if}}{{!--
     --}}{{/if}}{{!--
+
   --}}{{/each}}{{!--
 --}}{{/inline}}
 

--- a/test/references.json
+++ b/test/references.json
@@ -1,5 +1,32 @@
 [
   {
+    "title": "Positional auxiliaries in Biloxi",
+    "type": "journal",
+    "authors": [{
+      "first_name": "David V.",
+      "last_name": "Kaufman"
+    }],
+    "year": 2013,
+    "source": "International Journal of American Linguistics",
+    "pages": "283-299",
+    "volume": "79",
+    "issue": "2",
+    "id": "0792fc69-936a-3665-b917-e6aecae0cc9e",
+    "created": "2018-02-27T01:29:19.695Z",
+    "file_attached": false,
+    "profile_id": "16e9ee38-6fae-3fb0-bc64-3c2c28cb77dc",
+    "group_id": "63ed10d0-87d0-30d4-8590-eb5b241df109",
+    "last_modified": "2018-02-27T01:36:14.893Z",
+    "tags": ["Biloxi", "Chitimacha", "Southeast US", "auxiliaries"],
+    "read": false,
+    "starred": false,
+    "authored": false,
+    "confirmed": true,
+    "hidden": false,
+    "notes": "In this article Kaufman describes the system of positional auxiliary verbs in Biloxi (Siouan). Positional verbs in Biloxi are interestingly different from other Southeastern languages in that they are grammaticized as auxiliaries but exist alongside the lexical verbs 'sit', 'stand', 'lie', and 'move' as well. The forms also show some singular/plural suppletion. Occasionally more than one form may be used at once, and the positionals may also modify nouns. The positional auxiliaries in Biloxi impart a continuative aspect when used with verbs. Chitimacha is mentioned as another language of the Southeast with positional auxiliary verbs.",
+    "private_publication": false
+  },
+  {
     "title": "An introduction to the languages of the world",
     "type": "book",
     "authors": [{


### PR DESCRIPTION
When there is no author present, the editors are listed first, in place of the authors. In this case, the first and last name of the first editor in the list need to be reversed. This fix checks whether the reference has an authors field, and reverses the first editor in the list if so.

closes #43