### PR TITLE
NEW: use superscript for edition (#45)

### DIFF
--- a/dist/reference.hbs
+++ b/dist/reference.hbs
@@ -13,6 +13,19 @@
 {{!-- author list --}}
 {{#*inline "authors"}}{{#each authors}}{{> person}}{{/each}}{{/inline}}
 
+{{!-- edition --}}
+{{#*inline "edition"}}
+  {{#is edition '1'}}
+    1<sup>st</sup>
+  {{else is edition '2'}}
+    2<sup>nd</sup>
+  {{else is edition '3'}}
+    3<sup>rd</sup>
+  {{else}}
+    {{edition}}<sup>th</sup>
+  {{/is}}
+{{/inline}}
+
 {{!-- editor list --}}
 {{#*inline "editors"}}
   {{#each editors}}
@@ -65,7 +78,7 @@
       {{#is type "book"}}
         {{#if authors}}{{> authors}}{{else if editors}}{{> editors}}{{else}}unknown{{/if}}.
         {{year}}.
-        <cite>{{title}}</cite>{{#if edition}}, {{{edition}}} ed.{{/if}}{{> seriesInfo}}.
+        <cite>{{title}}</cite>{{#if edition}}, {{> edition}} ed.{{/if}}{{> seriesInfo}}.
         {{> publisherInfo}}.
       {{/is}}
 
@@ -73,7 +86,7 @@
         {{> authors}}.
         {{year}}.
         {{title}}. In {{#if editors}}{{> editors}}{{/if}}, <cite>{{source}}</cite>{{!--
-        --}}{{#if edition}}, {{{edition}}} ed.{{/if}}{{> seriesInfo}}.
+        --}}{{#if edition}}, {{> edition}} ed.{{/if}}{{> seriesInfo}}.
         {{> publisherInfo}}.
       {{/is}}
 

--- a/src/reference.hbs
+++ b/src/reference.hbs
@@ -13,6 +13,19 @@
 {{!-- author list --}}
 {{#*inline "authors"}}{{#each authors}}{{> person}}{{/each}}{{/inline}}
 
+{{!-- edition --}}
+{{#*inline "edition"}}
+  {{#is edition '1'}}
+    1<sup>st</sup>
+  {{else is edition '2'}}
+    2<sup>nd</sup>
+  {{else is edition '3'}}
+    3<sup>rd</sup>
+  {{else}}
+    {{edition}}<sup>th</sup>
+  {{/is}}
+{{/inline}}
+
 {{!-- editor list --}}
 {{#*inline "editors"}}
   {{#each editors}}
@@ -65,7 +78,7 @@
       {{#is type "book"}}
         {{#if authors}}{{> authors}}{{else if editors}}{{> editors}}{{else}}unknown{{/if}}.
         {{year}}.
-        <cite>{{title}}</cite>{{#if edition}}, {{{edition}}} ed.{{/if}}{{> seriesInfo}}.
+        <cite>{{title}}</cite>{{#if edition}}, {{> edition}} ed.{{/if}}{{> seriesInfo}}.
         {{> publisherInfo}}.
       {{/is}}
 
@@ -73,7 +86,7 @@
         {{> authors}}.
         {{year}}.
         {{title}}. In {{#if editors}}{{> editors}}{{/if}}, <cite>{{source}}</cite>{{!--
-        --}}{{#if edition}}, {{{edition}}} ed.{{/if}}{{> seriesInfo}}.
+        --}}{{#if edition}}, {{> edition}} ed.{{/if}}{{> seriesInfo}}.
         {{> publisherInfo}}.
       {{/is}}
 

--- a/test/reference.hbs
+++ b/test/reference.hbs
@@ -13,6 +13,19 @@
 {{!-- author list --}}
 {{#*inline "authors"}}{{#each authors}}{{> person}}{{/each}}{{/inline}}
 
+{{!-- edition --}}
+{{#*inline "edition"}}
+  {{#is edition '1'}}
+    1<sup>st</sup>
+  {{else is edition '2'}}
+    2<sup>nd</sup>
+  {{else is edition '3'}}
+    3<sup>rd</sup>
+  {{else}}
+    {{edition}}<sup>th</sup>
+  {{/is}}
+{{/inline}}
+
 {{!-- editor list --}}
 {{#*inline "editors"}}
   {{#each editors}}
@@ -65,7 +78,7 @@
       {{#is type "book"}}
         {{#if authors}}{{> authors}}{{else if editors}}{{> editors}}{{else}}unknown{{/if}}.
         {{year}}.
-        <cite>{{title}}</cite>{{#if edition}}, {{{edition}}} ed.{{/if}}{{> seriesInfo}}.
+        <cite>{{title}}</cite>{{#if edition}}, {{> edition}} ed.{{/if}}{{> seriesInfo}}.
         {{> publisherInfo}}.
       {{/is}}
 
@@ -73,7 +86,7 @@
         {{> authors}}.
         {{year}}.
         {{title}}. In {{#if editors}}{{> editors}}{{/if}}, <cite>{{source}}</cite>{{!--
-        --}}{{#if edition}}, {{{edition}}} ed.{{/if}}{{> seriesInfo}}.
+        --}}{{#if edition}}, {{> edition}} ed.{{/if}}{{> seriesInfo}}.
         {{> publisherInfo}}.
       {{/is}}
 

--- a/test/references.json
+++ b/test/references.json
@@ -1,5 +1,34 @@
 [
   {
+    "title": "A Choctaw reference grammar",
+    "type": "book",
+    "authors": [{
+      "first_name": "George Aaron",
+      "last_name": "Broadwell"
+    }],
+    "year": 2006,
+    "websites": ["https://www.amazon.com/Choctaw-Reference-Grammar-Anthropology-American/dp/0803213158/ref=sr_1_1?ie=UTF8&qid=1487728705&sr=8-1&keywords=choctaw+reference+grammar"],
+    "publisher": "University of Nebraska Press",
+    "city": "Lincoln, Nebraska",
+    "series": "Studies in the Anthropology of North American Indians",
+    "id": "f9491554-9149-3947-b093-33d226cbb782",
+    "created": "2017-02-22T03:14:00.000Z",
+    "file_attached": false,
+    "profile_id": "16e9ee38-6fae-3fb0-bc64-3c2c28cb77dc",
+    "group_id": "63ed10d0-87d0-30d4-8590-eb5b241df109",
+    "last_modified": "2017-03-14T14:22:53.186Z",
+    "tags": ["Chitimacha", "Chitimacha:minor", "Choctaw", "Muskogean", "Southeast US"],
+    "read": true,
+    "starred": false,
+    "authored": false,
+    "confirmed": true,
+    "hidden": false,
+    "citation_key": "Broadwell2006",
+    "notes": "Broadwell mentions briefly that Haas (1951, 1952) considered the possibility that Chitimacha was distantly related to Muskogean.",
+    "private_publication": false,
+    "edition": "3"
+  },
+  {
     "title": "Positional auxiliaries in Biloxi",
     "type": "journal",
     "authors": [{
@@ -49,7 +78,9 @@
     "hidden": false,
     "citation_key": "Lyovin1997",
     "notes": "A 2-sentence entry on Chitimacha is on p. 315: &quot;The Chitimacha language is now extinct. There are about 300 Chitimacha Indians living in southern Louisiana.&quot;",
-    "private_publication": false
+    "private_publication": false,
+    "edition": "1",
+    "publisher": "Oxford University Press"
   },
   {
     "title": "Classifiers: A typology of noun categorization devices",
@@ -78,7 +109,8 @@
     "citation_key": "Aikhenvald2000",
     "notes": "Following Campbell (1997:342), Aikhenvald analyses Chitimacha as having a set of &quot;suppletive classificatory verbs&quot; which alternate on the basis of position, orientation, or stance in space.",
     "private_publication": false,
-    "abstract": "Almost all languages have some grammatical means for categorizing nouns. This book provides a comprehensive and original analysis of noun categorization devices all over the world. It will interest typologists, those working in the fields of morphosyntactic variation and lexical semantics, as well as anthropologists and all other scholars interested in the mechanisms of human cognition."
+    "abstract": "Almost all languages have some grammatical means for categorizing nouns. This book provides a comprehensive and original analysis of noun categorization devices all over the world. It will interest typologists, those working in the fields of morphosyntactic variation and lexical semantics, as well as anthropologists and all other scholars interested in the mechanisms of human cognition.",
+    "edition": "4"
   },
   {
     "type": "book",
@@ -215,7 +247,6 @@
     ],
     "publisher": "Elsevier",
     "city": "Oxford",
-    "edition": "2",
     "editors": [
       {
         "last_name": "Brown",


### PR DESCRIPTION
This change now displays the edition field using `1st`, `2nd`, `3rd`, or `nth` as appropriately, with the abbreviation in a `<sup>` tag.

closes #45