### PR TITLE
NEW: replace hyphens in pages with en dashes (#47)

### DIFF
--- a/dist/reference.hbs
+++ b/dist/reference.hbs
@@ -58,6 +58,9 @@
   --}}{{/each}}{{!--
 --}}{{/inline}}
 
+{{!-- pages --}}
+{{#*inline "pages"}}{{#replace '-' '–'}}{{pages}}{{/replace}}{{/inline}}
+
 {{!-- publisher info --}}
 {{#*inline "publisherInfo"}}{{!--
   --}}{{#if publisher}}{{publisher}}{{!--
@@ -122,14 +125,14 @@
         {{> authors}}.
         {{year}}.
         {{title}}.
-        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{pages}}.
+        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{> pages}}.
       {{/is}}
 
       {{#is type "journal"}}
         {{> authors}}.
         {{year}}.
         {{title}}.
-        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{pages}}.
+        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{> pages}}.
       {{/is}}
 
       {{#is type "thesis"}}

--- a/src/reference.hbs
+++ b/src/reference.hbs
@@ -58,6 +58,9 @@
   --}}{{/each}}{{!--
 --}}{{/inline}}
 
+{{!-- pages --}}
+{{#*inline "pages"}}{{#replace '-' '–'}}{{pages}}{{/replace}}{{/inline}}
+
 {{!-- publisher info --}}
 {{#*inline "publisherInfo"}}{{!--
   --}}{{#if publisher}}{{publisher}}{{!--
@@ -122,14 +125,14 @@
         {{> authors}}.
         {{year}}.
         {{title}}.
-        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{pages}}.
+        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{> pages}}.
       {{/is}}
 
       {{#is type "journal"}}
         {{> authors}}.
         {{year}}.
         {{title}}.
-        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{pages}}.
+        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{> pages}}.
       {{/is}}
 
       {{#is type "thesis"}}

--- a/test/reference.hbs
+++ b/test/reference.hbs
@@ -58,6 +58,9 @@
   --}}{{/each}}{{!--
 --}}{{/inline}}
 
+{{!-- pages --}}
+{{#*inline "pages"}}{{#replace '-' '–'}}{{pages}}{{/replace}}{{/inline}}
+
 {{!-- publisher info --}}
 {{#*inline "publisherInfo"}}{{!--
   --}}{{#if publisher}}{{publisher}}{{!--
@@ -122,14 +125,14 @@
         {{> authors}}.
         {{year}}.
         {{title}}.
-        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{pages}}.
+        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{> pages}}.
       {{/is}}
 
       {{#is type "journal"}}
         {{> authors}}.
         {{year}}.
         {{title}}.
-        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{pages}}.
+        <cite>{{source}}</cite> {{volume}}{{#if issue}}({{issue}}){{/if}}: {{> pages}}.
       {{/is}}
 
       {{#is type "thesis"}}


### PR DESCRIPTION
This is a typographic improvement that finds any hyphens inside the `pages` field, an replaces them with en dashes.

closes #47